### PR TITLE
ci: protect main and harden vite graph canary

### DIFF
--- a/.github/rulesets/main-required-checks.json
+++ b/.github/rulesets/main-required-checks.json
@@ -1,0 +1,57 @@
+{
+  "name": "Protect main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/heads/main"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          {
+            "context": "python-core (3.10)"
+          },
+          {
+            "context": "python-core (3.12)"
+          },
+          {
+            "context": "python-core (3.13)"
+          },
+          {
+            "context": "python-reconstruction"
+          },
+          {
+            "context": "frontend"
+          },
+          {
+            "context": "comfyui-integration (minimum)"
+          },
+          {
+            "context": "comfyui-integration (v0.34.0)"
+          },
+          {
+            "context": "comfyui-browser"
+          },
+          {
+            "context": "comfyui-browser-pinned-frontend"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/.github/workflows/vite-module-graph-canary.yml
+++ b/.github/workflows/vite-module-graph-canary.yml
@@ -2,12 +2,18 @@ name: Vite module graph canary
 
 on:
   workflow_dispatch:
+  push:
+    paths:
+      - "web-src/**"
+      - "vite.config.mjs"
+      - "package*.json"
+      - ".github/workflows/vite-module-graph-canary.yml"
+      - "scripts/compare_vite_graphs.mjs"
   pull_request:
     paths:
       - "web-src/**"
       - "vite.config.mjs"
-      - "package.json"
-      - "package-lock.json"
+      - "package*.json"
       - ".github/workflows/vite-module-graph-canary.yml"
       - "scripts/compare_vite_graphs.mjs"
 

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -37,11 +37,40 @@ This file documents the repository policy only. Applying or changing branch
 protection on the remote repository is an administrative action and must be
 performed separately with explicit authorization.
 
-**Remote state: unverified.** The GitHub branch-protection API is not readable
-with the tokens available to CI or to review tooling (`403 Resource not
-accessible by integration`), so the live required-check set on the protected
-branch cannot be confirmed against this list from outside. Treat any claim that
-these contexts are enforced as unverified until a repository admin checks the
-branch settings directly. In particular, `comfyui-browser-pinned-frontend` was
-added to this policy after the initial protection was configured and must be
-added to the remote required-check set by hand.
+## Repository ruleset payload
+
+The canonical repository-ruleset payload is tracked at
+`.github/rulesets/main-required-checks.json`. It targets only
+`refs/heads/main`, enables strict required status checks, and intentionally
+excludes these canaries from the required set:
+
+```text
+comfyui-integration (master)
+comfyui-browser-latest-frontend
+adapter-contract-canary
+Vite module graph canary
+```
+
+Apply it with a GitHub token that has repository `Administration` write
+permission:
+
+```powershell
+gh api `
+  --method POST `
+  -H "Accept: application/vnd.github+json" `
+  -H "X-GitHub-Api-Version: 2026-03-10" `
+  /repos/MajoorWaldi/ComfyUI-Majoor-OmniCam/rulesets `
+  --input .github/rulesets/main-required-checks.json
+```
+
+Then verify both endpoints:
+
+```powershell
+gh api /repos/MajoorWaldi/ComfyUI-Majoor-OmniCam/rulesets
+gh api /repos/MajoorWaldi/ComfyUI-Majoor-OmniCam/rules/branches/main
+```
+
+**Remote state checked on 2026-09-08:** repository ruleset `Protect main`
+(`22587947`) is active for `refs/heads/main`. It blocks branch deletion,
+blocks non-fast-forward updates, and requires the strict status-check set
+listed above before `main` can be updated.

--- a/scripts/compare_vite_graphs.mjs
+++ b/scripts/compare_vite_graphs.mjs
@@ -12,21 +12,144 @@ const [a, b] = await Promise.all(
   files.map(async (path) => JSON.parse(await readFile(path, "utf8"))),
 );
 
-const left = new Set(a.modules);
-const right = new Set(b.modules);
+function uniqueSorted(values) {
+  return [...new Set(values.filter(Boolean))].sort();
+}
 
-const onlyLeft = [...left].filter((id) => !right.has(id)).sort();
-const onlyRight = [...right].filter((id) => !left.has(id)).sort();
+function setDiff(left, right) {
+  const leftSet = new Set(left);
+  const rightSet = new Set(right);
+  return {
+    onlyLeft: [...leftSet].filter((id) => !rightSet.has(id)).sort(),
+    onlyRight: [...rightSet].filter((id) => !leftSet.has(id)).sort(),
+  };
+}
+
+function normalizeModuleList(values = []) {
+  return uniqueSorted(values.map((value) => String(value).replaceAll("\\", "/")));
+}
+
+function normalizeChunk(chunk) {
+  const facadeModuleId = chunk.facadeModuleId ?? chunk.facade ?? null;
+  const normalizedFacade = facadeModuleId ? String(facadeModuleId).replaceAll("\\", "/") : null;
+  const name = chunk.name ? String(chunk.name) : "anonymous";
+  const kind = chunk.isEntry ? "entry" : chunk.isDynamicEntry ? "lazy" : "chunk";
+  const id = chunk.logicalId ? String(chunk.logicalId) : `${kind}:${normalizedFacade || name}`;
+
+  return {
+    id,
+    name,
+    facadeModuleId: normalizedFacade,
+    isEntry: Boolean(chunk.isEntry),
+    isDynamicEntry: Boolean(chunk.isDynamicEntry),
+    dynamicImports: normalizeModuleList(chunk.dynamicImports),
+    modules: normalizeModuleList(chunk.modules),
+  };
+}
+
+function chunkMap(report) {
+  return new Map((report.chunks || []).map((chunk) => {
+    const normalized = normalizeChunk(chunk);
+    return [normalized.id, normalized];
+  }));
+}
+
+function pairwiseListDiff(leftMap, rightMap, property) {
+  const rows = [];
+  const ids = uniqueSorted([...leftMap.keys(), ...rightMap.keys()]);
+
+  for (const id of ids) {
+    const leftChunk = leftMap.get(id);
+    const rightChunk = rightMap.get(id);
+
+    if (!leftChunk || !rightChunk) {
+      rows.push({
+        chunk: id,
+        only_left: leftChunk ? leftChunk[property] : [],
+        only_right: rightChunk ? rightChunk[property] : [],
+      });
+      continue;
+    }
+
+    const diff = setDiff(leftChunk[property], rightChunk[property]);
+    if (diff.onlyLeft.length || diff.onlyRight.length) {
+      rows.push({
+        chunk: id,
+        only_left: diff.onlyLeft,
+        only_right: diff.onlyRight,
+      });
+    }
+  }
+
+  return rows;
+}
+
+function chunkShape(report) {
+  return [...chunkMap(report).values()]
+    .map((chunk) => ({
+      id: chunk.id,
+      name: chunk.name,
+      facadeModuleId: chunk.facadeModuleId,
+      isEntry: chunk.isEntry,
+      isDynamicEntry: chunk.isDynamicEntry,
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function publicEntrypoints(report) {
+  return chunkShape(report)
+    .filter((chunk) => chunk.isEntry)
+    .map((chunk) => chunk.id);
+}
+
+function countPairwiseDelta(rows) {
+  return rows.reduce((total, row) => total + row.only_left.length + row.only_right.length, 0);
+}
+
+const left = normalizeModuleList(a.modules);
+const right = normalizeModuleList(b.modules);
+const moduleDiff = setDiff(left, right);
+const leftChunks = chunkMap(a);
+const rightChunks = chunkMap(b);
+const chunkIdDiff = setDiff([...leftChunks.keys()].sort(), [...rightChunks.keys()].sort());
+const chunkModuleDiffs = pairwiseListDiff(leftChunks, rightChunks, "modules");
+const dynamicImportDiffs = pairwiseListDiff(leftChunks, rightChunks, "dynamicImports");
+const entrypointDiff = setDiff(publicEntrypoints(a), publicEntrypoints(b));
+
+const moduleDelta = moduleDiff.onlyLeft.length + moduleDiff.onlyRight.length;
+const chunkIdDelta = chunkIdDiff.onlyLeft.length + chunkIdDiff.onlyRight.length;
+const chunkModuleDelta = countPairwiseDelta(chunkModuleDiffs);
+const dynamicImportDelta = countPairwiseDelta(dynamicImportDiffs);
+const entrypointDelta = entrypointDiff.onlyLeft.length + entrypointDiff.onlyRight.length;
+const delta = moduleDelta + chunkIdDelta + chunkModuleDelta + dynamicImportDelta + entrypointDelta;
 
 console.log(JSON.stringify({
   left: { platform: a.platform, module_count: a.module_count },
   right: { platform: b.platform, module_count: b.module_count },
-  common_count: [...left].filter((id) => right.has(id)).length,
-  delta: onlyLeft.length + onlyRight.length,
-  only_left: onlyLeft,
-  only_right: onlyRight,
+  common_count: left.filter((id) => right.includes(id)).length,
+  delta,
+  module_delta: moduleDelta,
+  chunk_delta: chunkIdDelta + chunkModuleDelta,
+  dynamic_import_delta: dynamicImportDelta,
+  entrypoint_delta: entrypointDelta,
+  only_left: moduleDiff.onlyLeft,
+  only_right: moduleDiff.onlyRight,
+  chunk_ids: {
+    only_left: chunkIdDiff.onlyLeft,
+    only_right: chunkIdDiff.onlyRight,
+  },
+  chunk_modules: chunkModuleDiffs,
+  dynamic_imports: dynamicImportDiffs,
+  public_entrypoints: {
+    only_left: entrypointDiff.onlyLeft,
+    only_right: entrypointDiff.onlyRight,
+  },
+  chunk_shape: {
+    left: chunkShape(a),
+    right: chunkShape(b),
+  },
 }, null, 2));
 
-if (strict && (onlyLeft.length || onlyRight.length)) {
+if (strict && delta) {
   process.exitCode = 1;
 }

--- a/tests/frontend/vite-graph-compare.node.mjs
+++ b/tests/frontend/vite-graph-compare.node.mjs
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+
+const ROOT = resolve(import.meta.dirname, "..", "..");
+const SCRIPT = resolve(ROOT, "scripts", "compare_vite_graphs.mjs");
+
+function writeReport(directory, name, overrides) {
+  const report = {
+    schema_version: 1,
+    platform: name,
+    node: process.version,
+    module_count: 4,
+    modules: ["A.js", "B.js", "C.js", "D.js"],
+    chunks: [
+      {
+        name: "omnicam",
+        facadeModuleId: "web-src/main.js",
+        isEntry: true,
+        isDynamicEntry: false,
+        dynamicImports: [],
+        modules: ["A.js", "B.js"],
+      },
+      {
+        name: "lazy-director",
+        facadeModuleId: "web-src/director.js",
+        isEntry: false,
+        isDynamicEntry: true,
+        dynamicImports: [],
+        modules: ["C.js", "D.js"],
+      },
+    ],
+    ...overrides,
+  };
+  const path = join(directory, `${name}.json`);
+  writeFileSync(path, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  return path;
+}
+
+function compare(left, right, strict = true) {
+  const args = [SCRIPT, left, right, strict ? "--strict" : "--report-only"];
+  const result = spawnSync(process.execPath, args, { cwd: ROOT, encoding: "utf8" });
+  assert.equal(result.stderr, "");
+  return {
+    ...result,
+    report: JSON.parse(result.stdout),
+  };
+}
+
+test("strict comparison fails when chunk membership differs despite identical modules", () => {
+  const dir = mkdtempSync(join(tmpdir(), "omnicam-vite-graph-"));
+  const linux = writeReport(dir, "linux", {});
+  const windows = writeReport(dir, "windows", {
+    chunks: [
+      {
+        name: "omnicam",
+        facadeModuleId: "web-src/main.js",
+        isEntry: true,
+        isDynamicEntry: false,
+        dynamicImports: [],
+        modules: ["A.js", "C.js"],
+      },
+      {
+        name: "lazy-director",
+        facadeModuleId: "web-src/director.js",
+        isEntry: false,
+        isDynamicEntry: true,
+        dynamicImports: [],
+        modules: ["B.js", "D.js"],
+      },
+    ],
+  });
+
+  const result = compare(linux, windows);
+
+  assert.equal(result.status, 1);
+  assert.equal(result.report.module_delta, 0);
+  assert.equal(result.report.chunk_delta, 4);
+});
+
+test("strict comparison fails when dynamic imports differ", () => {
+  const dir = mkdtempSync(join(tmpdir(), "omnicam-vite-graph-"));
+  const linux = writeReport(dir, "linux", {});
+  const windows = writeReport(dir, "windows", {
+    chunks: [
+      {
+        name: "omnicam",
+        facadeModuleId: "web-src/main.js",
+        isEntry: true,
+        isDynamicEntry: false,
+        dynamicImports: ["web-src/monitor.js"],
+        modules: ["A.js", "B.js"],
+      },
+      {
+        name: "lazy-director",
+        facadeModuleId: "web-src/director.js",
+        isEntry: false,
+        isDynamicEntry: true,
+        dynamicImports: [],
+        modules: ["C.js", "D.js"],
+      },
+    ],
+  });
+
+  const result = compare(linux, windows);
+
+  assert.equal(result.status, 1);
+  assert.equal(result.report.dynamic_import_delta, 1);
+});
+
+test("strict comparison fails when public entrypoints differ", () => {
+  const dir = mkdtempSync(join(tmpdir(), "omnicam-vite-graph-"));
+  const linux = writeReport(dir, "linux", {});
+  const windows = writeReport(dir, "windows", {
+    chunks: [
+      {
+        name: "omnicam",
+        facadeModuleId: "web-src/main.js",
+        isEntry: true,
+        isDynamicEntry: false,
+        dynamicImports: [],
+        modules: ["A.js", "B.js"],
+      },
+      {
+        name: "director",
+        facadeModuleId: "web-src/director.js",
+        isEntry: true,
+        isDynamicEntry: false,
+        dynamicImports: [],
+        modules: ["C.js", "D.js"],
+      },
+    ],
+  });
+
+  const result = compare(linux, windows);
+
+  assert.equal(result.status, 1);
+  assert.equal(result.report.entrypoint_delta, 1);
+});

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -129,6 +129,14 @@ def test_ci_frontend_lanes_split_pinned_and_latest_canary() -> None:
     assert old_name not in workflow
 
 
+def test_vite_module_graph_canary_runs_on_frontend_pushes() -> None:
+    workflow = _text(".github/workflows/vite-module-graph-canary.yml")
+    assert "  push:" in workflow
+    assert '      - "web-src/**"' in workflow
+    assert '      - "vite.config.mjs"' in workflow
+    assert '      - "package*.json"' in workflow
+
+
 def test_package_never_imports_itself_by_absolute_name() -> None:
     """ComfyUI loads a custom node under its *directory* name.
 

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -53,11 +53,17 @@ function publicEntryStub() {
 function normalizeModuleId(id) {
   if (!id) return null;
 
-  const clean = String(id).split("?")[0];
-  const root = resolve(".");
-  const rel = clean.startsWith(root) ? relative(root, clean) : clean;
+  const clean = String(id).split("?")[0].replaceAll("\\", "/");
+  const root = resolve(".").replaceAll("\\", "/");
+  const rel = clean.startsWith(root) ? relative(root, clean).replaceAll("\\", "/") : clean;
 
-  return rel.replaceAll("\\", "/");
+  return rel;
+}
+
+function logicalChunkId(chunk) {
+  const facade = normalizeModuleId(chunk.facadeModuleId);
+  const kind = chunk.isEntry ? "entry" : chunk.isDynamicEntry ? "lazy" : "chunk";
+  return `${kind}:${facade || chunk.name}`;
 }
 
 function moduleGraphAudit() {
@@ -73,17 +79,28 @@ function moduleGraphAudit() {
         .filter(Boolean)
         .sort();
 
-      const chunks = Object.values(bundle)
-        .filter((item) => item.type === "chunk")
+      const outputChunks = Object.values(bundle).filter((item) => item.type === "chunk");
+      const chunkIdByFileName = new Map(outputChunks.map((chunk) => [chunk.fileName, logicalChunkId(chunk)]));
+
+      const chunks = outputChunks
         .map((chunk) => ({
           name: chunk.name,
-          facade: normalizeModuleId(chunk.facadeModuleId),
+          logicalId: logicalChunkId(chunk),
+          facadeModuleId: normalizeModuleId(chunk.facadeModuleId),
+          isEntry: chunk.isEntry,
+          isDynamicEntry: chunk.isDynamicEntry,
+          dynamicImports: chunk.dynamicImports
+            .map((id) => chunkIdByFileName.get(id) || normalizeModuleId(id))
+            .filter(Boolean)
+            .sort(),
           modules: Object.keys(chunk.modules)
             .map(normalizeModuleId)
             .filter(Boolean)
             .sort(),
         }))
-        .sort((a, b) => String(a.facade || a.name).localeCompare(String(b.facade || b.name)));
+        .sort((a, b) => (
+          String(a.facadeModuleId || a.name).localeCompare(String(b.facadeModuleId || b.name))
+        ));
 
       const report = {
         schema_version: 1,


### PR DESCRIPTION
## Summary
- add the repository ruleset payload and update branch-protection docs with the active remote ruleset state
- extend the Vite graph audit/comparator to compare logical chunks, facade IDs, dynamic imports, public entrypoints, and per-chunk module membership
- run the Vite module graph canary on frontend-related pushes as well as PRs

## Verification
- node --test tests/frontend/vite-graph-compare.node.mjs
- npm run build
- node scripts\\compare_vite_graphs.mjs vite-graph-local.json vite-graph-local.json --strict
- npm run check
- python -m pytest tests/test_release_contract.py -q