### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/omnicam/__init__.py
+++ b/omnicam/__init__.py
@@ -5,6 +5,6 @@ and tests can run in normal Python tooling outside a live ComfyUI process.
 The custom-node entrypoint lives in the repository root ``__init__.py``.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = ["__version__"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-majoor-omnicam-frontend",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-majoor-omnicam-frontend",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "mediabunny": "1.53.1",
         "three": "0.180.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "comfyui-majoor-omnicam-frontend",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "majoor-omnicam"
-version = "0.2.0"
+version = "0.3.0"
 description = "Interactive camera authoring and proxy-reference playblasts for ComfyUI video models."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bump version 0.2.0 → 0.3.0 across pyproject.toml, package.json, package-lock.json and omnicam/__init__.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)